### PR TITLE
Assist medals

### DIFF
--- a/src/Pages/MedalsView.tsx
+++ b/src/Pages/MedalsView.tsx
@@ -160,6 +160,9 @@ export function MedalsView(props: ViewProps)
 						<MedalTypeBreakdown type={MedalType.Skill} medals={serviceRecord.medals} showAll={showAll} />
 					</Grid>
 					<Grid item xs={12} md={6} xl={4}>
+						<MedalTypeBreakdown type={MedalType.Assists} medals={serviceRecord.medals} showAll={showAll} />
+					</Grid>
+					<Grid item xs={12} md={6} xl={4}>
 						<MedalTypeBreakdown type={MedalType.GameEnd} medals={serviceRecord.medals} showAll={showAll} />
 					</Grid>
 					<Grid item xs={12} md={6} xl={4}>


### PR DESCRIPTION
Noticed there were some ingame medals missing in the overview, for example "Spotter" and "Treasure Hunter". This is due to the assist medals not having a category.